### PR TITLE
feat(db): PostgreSQL schema and migration baseline (Step 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,106 @@
 # polymarket-winner-scanner
 
 Internal project: scan high-winrate, high-volume Polymarket accounts and sync to PostgreSQL.
+
+## Architecture
+
+```
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│  Collector  │───▶│   Scorer    │───▶│  Selector   │───▶│   Storage   │
+└─────────────┘    └─────────────┘    └─────────────┘    └─────────────┘
+       │                  │                  │                  │
+       ▼                  ▼                  ▼                  ▼
+  Polymarket API    Calculate metrics   Apply filters      PostgreSQL
+  /trades           win_rate, volume    min_trades,        runs
+  /positions        pnl, score          min_volume,        accounts
+  /activity                             min_winrate        account_metrics_snapshot
+                                                          selected_accounts
+```
+
+## Database Schema
+
+### Core Tables
+
+- **runs**: Track each sync run's metadata and status
+- **accounts**: Account master data with cumulative metrics
+- **account_metrics_snapshot**: Snapshot of account metrics at each run
+- **selected_accounts**: Accounts that passed selection criteria
+
+### Optional Tables
+
+- **raw_trades**: Store raw trade data for deeper analysis
+- **raw_positions**: Store position snapshots
+
+## Quick Start
+
+```bash
+# Install dependencies
+npm install
+
+# Copy environment config
+cp .env.example .env
+
+# Run migrations (creates database if needed)
+npm run db:migrate
+
+# Run sync
+npm run sync -- --min-trades 50 --min-volume 5000 --min-winrate 0.58
+```
+
+## Development Status
+
+| Step | Description | Status |
+|------|-------------|--------|
+| 0 | Data source feasibility | ✅ Done |
+| 1 | DB schema + migrations | 🚧 In Progress |
+| 2 | Collector module | ⏳ Pending |
+| 3 | Scorer module | ⏳ Pending |
+| 4 | Selector module | ⏳ Pending |
+| 5 | CLI runner + testing | ⏳ Pending |
+
+## Metrics
+
+| Metric | Definition | Source |
+|--------|------------|--------|
+| strict_win_rate | wins / (wins + losses) for closed positions | /closed-positions |
+| proxy_win_rate | estimated from cashPnl > 0 | /positions + /activity |
+| total_trades | BUY + SELL transaction count | /activity |
+| total_volume_usd | sum(usdcSize) | /activity |
+| realized_pnl | sum(realizedPnl) | /positions |
+| confidence_score | closed_positions / total_positions | calculated |
+
+## Configuration
+
+Environment variables (see `.env.example`):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| DB_HOST | 192.168.26.208 | PostgreSQL host |
+| DB_PORT | 5432 | PostgreSQL port |
+| DB_USER | clawdbot | Database user |
+| DB_PASSWORD | - | Database password |
+| DB_NAME | polymarket_scanner | Database name |
+| MIN_TRADES | 50 | Minimum trades threshold |
+| MIN_VOLUME_USD | 5000 | Minimum volume threshold |
+| MIN_WIN_RATE | 0.58 | Minimum win rate threshold |
+
+## Project Structure
+
+```
+polymarket-winner-scanner/
+├── db/
+│   └── migrations/       # SQL migrations
+├── docs/
+│   └── data-source-report.md
+├── scripts/
+│   └── migrate.js        # Migration runner
+├── src/
+│   ├── db.js             # Database utilities
+│   ├── runner.js         # Main entry point
+│   ├── collector.js      # (TODO) API data collection
+│   ├── scorer.js         # (TODO) Metrics calculation
+│   └── selector.js       # (TODO) Account selection
+├── .env.example
+├── package.json
+└── README.md
+```

--- a/db/migrations/001_init.sql
+++ b/db/migrations/001_init.sql
@@ -1,0 +1,243 @@
+-- Migration: 001_init
+-- Description: Initial schema for polymarket-winner-scanner
+-- Date: 2026-02-14
+
+-- Enable UUID extension (if not already enabled)
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- ============================================================================
+-- Table: runs
+-- Purpose: Track each sync run's metadata and status
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS runs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    status VARCHAR(20) NOT NULL DEFAULT 'running' CHECK (status IN ('running', 'completed', 'failed')),
+    config JSONB,  -- Store run parameters (min_trades, min_volume, min_winrate, etc.)
+    error_message TEXT,
+    stats JSONB,   -- Summary stats: accounts_processed, accounts_selected, etc.
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_runs_started_at ON runs(started_at DESC);
+CREATE INDEX idx_runs_status ON runs(status);
+
+-- ============================================================================
+-- Table: accounts
+-- Purpose: Account master data with cumulative metrics
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS accounts (
+    address VARCHAR(42) PRIMARY KEY,  -- Ethereum address format (0x...)
+    
+    -- Metadata
+    first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_sync_run_id UUID REFERENCES runs(id),
+    
+    -- Cumulative metrics (updated on each sync)
+    total_trades INTEGER NOT NULL DEFAULT 0,
+    total_volume_usd DECIMAL(20, 4) NOT NULL DEFAULT 0,
+    total_positions INTEGER NOT NULL DEFAULT 0,
+    closed_positions INTEGER NOT NULL DEFAULT 0,
+    win_count INTEGER NOT NULL DEFAULT 0,
+    loss_count INTEGER NOT NULL DEFAULT 0,
+    
+    -- Derived metrics
+    strict_win_rate DECIMAL(6, 4),  -- wins / (wins + losses) for closed positions
+    proxy_win_rate DECIMAL(6, 4),   -- estimated from cashPnl
+    realized_pnl DECIMAL(20, 4) NOT NULL DEFAULT 0,
+    confidence_score DECIMAL(6, 4), -- closed_positions / total_positions
+    
+    -- Source tracking
+    discovery_method VARCHAR(50),  -- 'trades_stream', 'seed_list', 'market_scrape'
+    discovered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_accounts_strict_win_rate ON accounts(strict_win_rate DESC) WHERE strict_win_rate IS NOT NULL;
+CREATE INDEX idx_accounts_total_volume ON accounts(total_volume_usd DESC);
+CREATE INDEX idx_accounts_last_seen ON accounts(last_seen_at DESC);
+
+-- ============================================================================
+-- Table: account_metrics_snapshot
+-- Purpose: Snapshot of account metrics at each run (for historical tracking)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS account_metrics_snapshot (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    run_id UUID NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+    address VARCHAR(42) NOT NULL REFERENCES accounts(address),
+    
+    -- Snapshot metrics
+    strict_win_rate DECIMAL(6, 4),
+    proxy_win_rate DECIMAL(6, 4),
+    total_trades INTEGER NOT NULL DEFAULT 0,
+    total_volume_usd DECIMAL(20, 4) NOT NULL DEFAULT 0,
+    realized_pnl DECIMAL(20, 4) NOT NULL DEFAULT 0,
+    win_count INTEGER NOT NULL DEFAULT 0,
+    loss_count INTEGER NOT NULL DEFAULT 0,
+    closed_positions INTEGER NOT NULL DEFAULT 0,
+    confidence_score DECIMAL(6, 4),
+    
+    -- Composite score (configurable formula)
+    score DECIMAL(10, 4),
+    
+    -- Raw API response counts (for debugging/replay)
+    positions_count INTEGER,
+    activity_count INTEGER,
+    trades_count INTEGER,
+    
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    
+    UNIQUE(run_id, address)
+);
+
+CREATE INDEX idx_snapshot_run_id ON account_metrics_snapshot(run_id);
+CREATE INDEX idx_snapshot_address ON account_metrics_snapshot(address);
+CREATE INDEX idx_snapshot_score ON account_metrics_snapshot(score DESC);
+
+-- ============================================================================
+-- Table: selected_accounts
+-- Purpose: Store accounts that passed selection criteria for each run
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS selected_accounts (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    run_id UUID NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+    address VARCHAR(42) NOT NULL REFERENCES accounts(address),
+    
+    -- Selection metadata
+    reason_tags TEXT[],  -- ['high_winrate', 'high_volume', 'consistent']
+    selection_score DECIMAL(10, 4),
+    
+    -- Metrics at selection time
+    strict_win_rate DECIMAL(6, 4),
+    total_trades INTEGER,
+    total_volume_usd DECIMAL(20, 4),
+    realized_pnl DECIMAL(20, 4),
+    
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    
+    UNIQUE(run_id, address)
+);
+
+CREATE INDEX idx_selected_run_id ON selected_accounts(run_id);
+CREATE INDEX idx_selected_address ON selected_accounts(address);
+
+-- ============================================================================
+-- Table: raw_trades (optional - for storing raw trade data)
+-- Purpose: Store raw trade data for deeper analysis
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS raw_trades (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    address VARCHAR(42) NOT NULL REFERENCES accounts(address),
+    
+    -- Trade data from API
+    condition_id VARCHAR(100),
+    market_title TEXT,
+    outcome VARCHAR(50),
+    side VARCHAR(10) CHECK (side IN ('BUY', 'SELL')),
+    size DECIMAL(20, 8),
+    price DECIMAL(10, 6),
+    usdc_size DECIMAL(20, 4),
+    timestamp TIMESTAMPTZ,
+    
+    -- Tracking
+    run_id UUID REFERENCES runs(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_raw_trades_address ON raw_trades(address);
+CREATE INDEX idx_raw_trades_condition ON raw_trades(condition_id);
+CREATE INDEX idx_raw_trades_timestamp ON raw_trades(timestamp DESC);
+
+-- ============================================================================
+-- Table: raw_positions (optional - for storing position snapshots)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS raw_positions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    address VARCHAR(42) NOT NULL REFERENCES accounts(address),
+    
+    -- Position data from API
+    condition_id VARCHAR(100),
+    outcome VARCHAR(50),
+    size DECIMAL(20, 8),
+    avg_price DECIMAL(10, 6),
+    current_value DECIMAL(20, 4),
+    cash_pnl DECIMAL(20, 4),
+    realized_pnl DECIMAL(20, 4),
+    cur_price DECIMAL(10, 6),
+    
+    -- Settlement tracking
+    is_closed BOOLEAN DEFAULT FALSE,
+    resolved_at TIMESTAMPTZ,
+    
+    -- Tracking
+    run_id UUID REFERENCES runs(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_raw_positions_address ON raw_positions(address);
+CREATE INDEX idx_raw_positions_condition ON raw_positions(condition_id);
+CREATE INDEX idx_raw_positions_closed ON raw_positions(is_closed);
+
+-- ============================================================================
+-- Seed addresses table (for managing seed address lists)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS seed_addresses (
+    address VARCHAR(42) PRIMARY KEY,
+    source VARCHAR(100),  -- 'manual', 'community', 'api_discovered'
+    notes TEXT,
+    is_active BOOLEAN DEFAULT TRUE,
+    added_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ============================================================================
+-- Views
+-- ============================================================================
+
+-- View: Top accounts by win rate (with minimum thresholds)
+CREATE OR REPLACE VIEW v_top_accounts AS
+SELECT 
+    address,
+    strict_win_rate,
+    proxy_win_rate,
+    total_trades,
+    total_volume_usd,
+    realized_pnl,
+    win_count,
+    loss_count,
+    closed_positions,
+    confidence_score,
+    last_seen_at
+FROM accounts
+WHERE 
+    total_trades >= 10
+    AND total_volume_usd >= 100
+    AND strict_win_rate IS NOT NULL
+ORDER BY strict_win_rate DESC, total_volume_usd DESC;
+
+-- View: Recent sync runs
+CREATE OR REPLACE VIEW v_recent_runs AS
+SELECT 
+    id,
+    started_at,
+    completed_at,
+    status,
+    stats->>'accounts_processed' AS accounts_processed,
+    stats->>'accounts_selected' AS accounts_selected,
+    EXTRACT(EPOCH FROM (completed_at - started_at)) AS duration_seconds
+FROM runs
+ORDER BY started_at DESC
+LIMIT 20;
+
+-- ============================================================================
+-- Migration tracking
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version VARCHAR(20) PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO schema_migrations (version) VALUES ('001');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "polymarket-winner-scanner",
+  "version": "0.1.0",
+  "description": "Scan high-winrate, high-volume Polymarket accounts and sync to PostgreSQL",
+  "main": "src/index.js",
+  "scripts": {
+    "db:migrate": "node scripts/migrate.js",
+    "db:reset": "node scripts/migrate.js --reset",
+    "sync": "node src/runner.js",
+    "test": "node --test"
+  },
+  "keywords": ["polymarket", "scanner", "trading"],
+  "author": "internal",
+  "license": "MIT",
+  "dependencies": {
+    "pg": "^8.11.0",
+    "dotenv": "^16.3.1"
+  },
+  "devDependencies": {
+    "node-fetch": "^2.7.0"
+  }
+}

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,0 +1,125 @@
+/**
+ * Migration Runner
+ * Usage: node scripts/migrate.js [--reset]
+ */
+
+const { Client } = require('pg');
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config();
+
+const DB_CONFIG = {
+  host: process.env.DB_HOST || '192.168.26.208',
+  port: parseInt(process.env.DB_PORT || '5432'),
+  user: process.env.DB_USER || 'clawdbot',
+  password: process.env.DB_PASSWORD || 'ClawdBot_DB_2024',
+  database: process.env.DB_NAME || 'polymarket_scanner'
+};
+
+const MIGRATIONS_DIR = path.join(__dirname, '..', 'db', 'migrations');
+
+async function runMigrations() {
+  const client = new Client(DB_CONFIG);
+  
+  try {
+    await client.connect();
+    console.log('Connected to database:', DB_CONFIG.database);
+    
+    // Check if schema_migrations table exists
+    const tableCheck = await client.query(`
+      SELECT EXISTS (
+        SELECT FROM information_schema.tables 
+        WHERE table_schema = 'public' 
+        AND table_name = 'schema_migrations'
+      );
+    `);
+    
+    const migrationsTableExists = tableCheck.rows[0].exists;
+    
+    // Get applied migrations
+    let appliedMigrations = [];
+    if (migrationsTableExists) {
+      const result = await client.query('SELECT version FROM schema_migrations ORDER BY version');
+      appliedMigrations = result.rows.map(r => r.version);
+    }
+    
+    // Get migration files
+    const files = fs.readdirSync(MIGRATIONS_DIR)
+      .filter(f => f.endsWith('.sql'))
+      .sort();
+    
+    console.log('Found migrations:', files.map(f => f.replace('.sql', '')).join(', '));
+    console.log('Applied migrations:', appliedMigrations.join(', ') || 'none');
+    
+    // Apply pending migrations
+    for (const file of files) {
+      const version = file.replace('.sql', '').split('_')[0];
+      
+      if (appliedMigrations.includes(version)) {
+        console.log(`Skipping ${file} (already applied)`);
+        continue;
+      }
+      
+      console.log(`Applying ${file}...`);
+      const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, file), 'utf8');
+      
+      await client.query('BEGIN');
+      try {
+        await client.query(sql);
+        await client.query('COMMIT');
+        console.log(`✓ Applied ${file}`);
+      } catch (err) {
+        await client.query('ROLLBACK');
+        throw err;
+      }
+    }
+    
+    console.log('All migrations applied successfully!');
+    
+  } catch (error) {
+    console.error('Migration failed:', error.message);
+    process.exit(1);
+  } finally {
+    await client.end();
+  }
+}
+
+async function resetDatabase() {
+  const client = new Client({ ...DB_CONFIG, database: 'postgres' });
+  
+  try {
+    await client.connect();
+    console.log('Resetting database:', DB_CONFIG.database);
+    
+    // Terminate existing connections
+    await client.query(`
+      SELECT pg_terminate_backend(pg_stat_activity.pid)
+      FROM pg_stat_activity
+      WHERE pg_stat_activity.datname = '${DB_CONFIG.database}'
+      AND pid <> pg_backend_pid();
+    `);
+    
+    // Drop and recreate database
+    await client.query(`DROP DATABASE IF EXISTS ${DB_CONFIG.database}`);
+    await client.query(`CREATE DATABASE ${DB_CONFIG.database}`);
+    
+    console.log('Database reset complete. Running migrations...');
+    
+    await client.end();
+    
+    // Run migrations on new database
+    await runMigrations();
+    
+  } catch (error) {
+    console.error('Reset failed:', error.message);
+    process.exit(1);
+  }
+}
+
+// Main
+const args = process.argv.slice(2);
+if (args.includes('--reset')) {
+  resetDatabase();
+} else {
+  runMigrations();
+}

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,57 @@
+/**
+ * Database connection utilities
+ */
+
+const { Pool } = require('pg');
+require('dotenv').config();
+
+const pool = new Pool({
+  host: process.env.DB_HOST || '192.168.26.208',
+  port: parseInt(process.env.DB_PORT || '5432'),
+  user: process.env.DB_USER || 'clawdbot',
+  password: process.env.DB_PASSWORD || 'ClawdBot_DB_2024',
+  database: process.env.DB_NAME || 'polymarket_scanner',
+  max: 10,
+  idleTimeoutMillis: 30000,
+  connectionTimeoutMillis: 2000
+});
+
+pool.on('error', (err) => {
+  console.error('Unexpected error on idle client', err);
+  process.exit(-1);
+});
+
+/**
+ * Execute a query
+ * @param {string} text - SQL query
+ * @param {Array} params - Query parameters
+ */
+async function query(text, params) {
+  const start = Date.now();
+  const result = await pool.query(text, params);
+  const duration = Date.now() - start;
+  console.log('Executed query', { text: text.substring(0, 100), duration, rows: result.rowCount });
+  return result;
+}
+
+/**
+ * Get a client from the pool
+ */
+async function getClient() {
+  const client = await pool.connect();
+  return client;
+}
+
+/**
+ * Close the pool
+ */
+async function close() {
+  await pool.end();
+}
+
+module.exports = {
+  pool,
+  query,
+  getClient,
+  close
+};

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,0 +1,109 @@
+/**
+ * Main runner entry point
+ * 
+ * Usage: npm run sync -- [options]
+ * Options:
+ *   --min-trades <n>      Minimum trade count (default: 50)
+ *   --min-volume <v>      Minimum volume in USD (default: 5000)
+ *   --min-winrate <r>     Minimum win rate (default: 0.58)
+ *   --seed-file <path>    Path to seed addresses file
+ */
+
+const { query, getClient, close } = require('./db');
+require('dotenv').config();
+
+// Placeholder modules (to be implemented in later steps)
+// const collector = require('./collector');
+// const scorer = require('./scorer');
+// const selector = require('./selector');
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const config = {
+    minTrades: parseInt(process.env.MIN_TRADES || '50'),
+    minVolumeUsd: parseFloat(process.env.MIN_VOLUME_USD || '5000'),
+    minWinRate: parseFloat(process.env.MIN_WIN_RATE || '0.58'),
+    seedFile: null
+  };
+  
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--min-trades':
+        config.minTrades = parseInt(args[++i]);
+        break;
+      case '--min-volume':
+        config.minVolumeUsd = parseFloat(args[++i]);
+        break;
+      case '--min-winrate':
+        config.minWinRate = parseFloat(args[++i]);
+        break;
+      case '--seed-file':
+        config.seedFile = args[++i];
+        break;
+    }
+  }
+  
+  return config;
+}
+
+async function createRun(config) {
+  const result = await query(
+    `INSERT INTO runs (status, config) VALUES ($1, $2) RETURNING id`,
+    ['running', JSON.stringify(config)]
+  );
+  return result.rows[0].id;
+}
+
+async function completeRun(runId, stats) {
+  await query(
+    `UPDATE runs SET status = $1, completed_at = NOW(), stats = $2 WHERE id = $3`,
+    ['completed', JSON.stringify(stats), runId]
+  );
+}
+
+async function failRun(runId, errorMessage) {
+  await query(
+    `UPDATE runs SET status = $1, completed_at = NOW(), error_message = $2 WHERE id = $3`,
+    ['failed', errorMessage, runId]
+  );
+}
+
+async function main() {
+  const config = parseArgs();
+  console.log('Starting sync with config:', config);
+  
+  let runId;
+  try {
+    runId = await createRun(config);
+    console.log('Created run:', runId);
+    
+    // TODO: Implement sync pipeline
+    // 1. Load seed addresses
+    // 2. Collect account data from Polymarket API
+    // 3. Calculate metrics (scorer)
+    // 4. Select accounts based on criteria
+    // 5. Store results
+    
+    console.log('Sync pipeline not yet implemented - this is Step 1 (schema only)');
+    
+    const stats = {
+      accounts_processed: 0,
+      accounts_selected: 0,
+      config_used: config
+    };
+    
+    await completeRun(runId, stats);
+    console.log('Run completed:', runId);
+    
+  } catch (error) {
+    console.error('Sync failed:', error);
+    if (runId) {
+      await failRun(runId, error.message);
+    }
+    process.exit(1);
+  } finally {
+    await close();
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

This PR implements Step 1 of the polymarket-winner-scanner project.

## Changes

### Database Schema
- `runs`: Track each sync run's metadata and status
- `accounts`: Account master data with cumulative metrics (total_trades, total_volume_usd, win_count, loss_count, strict_win_rate, proxy_win_rate, etc.)
- `account_metrics_snapshot`: Historical metrics snapshot per run
- `selected_accounts`: Accounts that passed selection criteria
- `raw_trades`, `raw_positions`: Optional raw data storage
- `seed_addresses`: Seed address management

### Views
- `v_top_accounts`: Top accounts by win rate with minimum thresholds
- `v_recent_runs`: Recent sync runs

### Code
- `scripts/migrate.js`: Migration runner with --reset support
- `src/db.js`: Database connection utilities
- `src/runner.js`: Main entry point skeleton

### Documentation
- Updated README with architecture diagram and usage

## Related
- Closes Issue #3 (Step 1 milestone)
- Based on data source report from Step 0

## Testing
Run migrations:
```bash
npm install
npm run db:migrate
```

## Reviewers
@1466488699784265826 (Sockey) - code review
@1466485600541610056 (Manny) - test verification